### PR TITLE
Redact git tokens and surface stderr

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -25,6 +25,7 @@ from prefect.blocks.system import Secret
 from prefect.filesystems import ReadableDeploymentStorage, WritableDeploymentStorage
 from prefect.logging.loggers import get_logger
 from prefect.utilities.collections import visit_collection
+from prefect.utilities.urls import redact_url_credentials
 
 
 @runtime_checkable
@@ -312,9 +313,17 @@ class GitRepository:
                     await run_process(cmd, cwd=self.destination)
                     self._logger.debug("Successfully fetched latest changes")
                 except subprocess.CalledProcessError as exc:
-                    self._logger.error(
-                        f"Failed to fetch latest changes with exit code {exc}"
+                    stderr = (
+                        redact_url_credentials(exc.stderr.decode().strip())
+                        if exc.stderr
+                        else ""
                     )
+                    message = (
+                        f"Failed to fetch latest changes with exit code {exc.returncode}"
+                    )
+                    if stderr:
+                        message += f": {stderr}"
+                    self._logger.error(message)
                     shutil.rmtree(self.destination)
                     await self._clone_repo()
 
@@ -338,9 +347,17 @@ class GitRepository:
                     await run_process(cmd, cwd=self.destination)
                     self._logger.debug("Successfully pulled latest changes")
                 except subprocess.CalledProcessError as exc:
-                    self._logger.error(
-                        f"Failed to pull latest changes with exit code {exc}"
+                    stderr = (
+                        redact_url_credentials(exc.stderr.decode().strip())
+                        if exc.stderr
+                        else ""
                     )
+                    message = (
+                        f"Failed to pull latest changes with exit code {exc.returncode}"
+                    )
+                    if stderr:
+                        message += f": {stderr}"
+                    self._logger.error(message)
                     shutil.rmtree(self.destination)
                     await self._clone_repo()
 
@@ -385,10 +402,17 @@ class GitRepository:
         except subprocess.CalledProcessError as exc:
             # Hide the command used to avoid leaking the access token
             exc_chain = None if self._credentials else exc
-            raise RuntimeError(
-                f"Failed to clone repository {self._url!r} with exit code"
-                f" {exc.returncode}."
-            ) from exc_chain
+            stderr = (
+                redact_url_credentials(exc.stderr.decode().strip())
+                if exc.stderr
+                else ""
+            )
+            message = (
+                f"Failed to clone repository {self._url!r} with exit code {exc.returncode}"
+            )
+            if stderr:
+                message += f": {stderr}"
+            raise RuntimeError(message) from exc_chain
 
         if self._commit_sha:
             # Fetch the commit

--- a/src/prefect/utilities/urls.py
+++ b/src/prefect/utilities/urls.py
@@ -2,6 +2,7 @@ import inspect
 import ipaddress
 import socket
 import urllib.parse
+import re
 from logging import Logger
 from string import Formatter
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
@@ -21,6 +22,31 @@ if TYPE_CHECKING:
     from prefect.variables import Variable
 
 logger: Logger = get_logger("utilities.urls")
+
+# Regular expression patterns used for credential redaction
+_URL_WITH_CREDENTIALS = re.compile(r"(https?://)[^:@\s]+:[^@/\s]+@")
+_URL_WITH_TOKEN = re.compile(r"(https?://)[^:@/\s]+@")
+
+
+def redact_url_credentials(text: str) -> str:
+    """Redact embedded credentials from URLs in a string.
+
+    This replaces any occurrences of ``https://user:token@host`` with
+    ``https://***:***@host`` and ``https://token@host`` with ``https://***@host``.
+
+    Args:
+        text: A string that may contain URLs with credentials.
+
+    Returns:
+        The string with any credentials redacted.
+    """
+
+    if not text:
+        return text
+
+    text = _URL_WITH_CREDENTIALS.sub(r"\1***:***@", text)
+    text = _URL_WITH_TOKEN.sub(r"\1***@", text)
+    return text
 
 # The following objects are excluded from UI URL generation because we lack a
 # directly-addressable URL:

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -1,5 +1,6 @@
 import re
 import shutil
+import subprocess
 from pathlib import Path
 from textwrap import dedent
 from typing import Optional
@@ -791,6 +792,33 @@ class TestGitRepository:
 
         mock_run_process.assert_has_awaits(expected_calls)
         assert mock_run_process.await_args_list == expected_calls
+
+    async def test_pull_code_logs_redacted_error(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        repo = GitRepository(url="https://github.com/org/repo.git")
+        repo.set_base_path(tmp_path)
+        (repo.destination / ".git").mkdir(parents=True)
+
+        success = MagicMock()
+        success.stdout = repo._url.encode()
+        error = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["git", "pull"],
+            stderr=b"fatal: https://oauth2:secret@github.com/org/repo.git",
+        )
+
+        run_process_mock = AsyncMock(side_effect=[success, error])
+        monkeypatch.setattr("prefect.runner.storage.run_process", run_process_mock)
+        clone_mock = AsyncMock()
+        monkeypatch.setattr(GitRepository, "_clone_repo", clone_mock)
+
+        with caplog.at_level("ERROR"):
+            await repo.pull_code()
+
+        clone_mock.assert_awaited_once()
+        assert any("https://***:***@github.com" in r.message for r in caplog.records)
+        assert any("fatal:" in r.message for r in caplog.records)
 
 
 class TestRemoteStorage:

--- a/tests/utilities/test_urls.py
+++ b/tests/utilities/test_urls.py
@@ -14,7 +14,11 @@ from prefect.server.schemas.states import State
 from prefect.settings import PREFECT_API_URL, PREFECT_UI_URL, temporary_settings
 from prefect.states import StateType
 from prefect.types._datetime import now
-from prefect.utilities.urls import url_for, validate_restricted_url
+from prefect.utilities.urls import (
+    redact_url_credentials,
+    url_for,
+    validate_restricted_url,
+)
 from prefect.variables import Variable
 
 MOCK_PREFECT_UI_URL = "https://ui.prefect.io"
@@ -415,3 +419,22 @@ def test_url_for_with_additional_format_kwargs_raises_if_placeholder_not_replace
         match="Unable to generate URL for worker because the following keys are missing: work_pool_name",
     ):
         url_for(obj="worker", obj_id="123e4567-e89b-12d3-a456-42661417400")
+
+
+def test_redact_url_credentials_with_user_and_token():
+    text = (
+        "fatal: could not read https://oauth2:secret@github.com/org/repo.git"
+    )
+    redacted = redact_url_credentials(text)
+    assert "secret" not in redacted
+    assert "oauth2" not in redacted
+    assert (
+        "https://***:***@github.com/org/repo.git" in redacted
+    )
+
+
+def test_redact_url_credentials_with_token_only():
+    text = "error: unable to access 'https://secret@github.com/org/repo.git'"
+    redacted = redact_url_credentials(text)
+    assert "secret" not in redacted
+    assert "https://***@github.com/org/repo.git" in redacted


### PR DESCRIPTION
## Summary
- add `redact_url_credentials` utility to strip credentials from URLs
- redact and log stderr from git fetch/pull/clone failures
- test URL redaction and logging of redacted git errors

## Testing
- `uv run pre-commit run --files src/prefect/utilities/urls.py src/prefect/runner/storage.py tests/utilities/test_urls.py tests/runner/test_storage.py` (failed: Failed to parse `uv.lock`)
- `pytest tests/utilities/test_urls.py::test_redact_url_credentials_with_user_and_token tests/utilities/test_urls.py::test_redact_url_credentials_with_token_only tests/runner/test_storage.py::TestGitRepository::test_pull_code_logs_redacted_error` (failed: ModuleNotFoundError: No module named 'sqlalchemy')

------
https://chatgpt.com/codex/tasks/task_e_689221a7145083239df12a55ef301b97