### PR TITLE
Release limiter tokens on aborted submissions

### DIFF
--- a/src/prefect/runner/_observers.py
+++ b/src/prefect/runner/_observers.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol
 from prefect.events.clients import PrefectEventSubscriber, get_events_subscriber
 from prefect.events.filters import EventFilter, EventNameFilter
 from prefect.logging.loggers import get_logger
+from websockets.exceptions import ConnectionClosedError
 
 
 class OnCancellingCallback(Protocol):
@@ -24,19 +25,22 @@ class FlowRunCancellingObserver:
             raise RuntimeError(
                 "Events subscriber not initialized. Please use `async with` to initialize the observer."
             )
-        async for event in self._events_subscriber:
-            try:
-                flow_run_id = uuid.UUID(
-                    event.resource["prefect.resource.id"].replace(
-                        "prefect.flow-run.", ""
+        try:
+            async for event in self._events_subscriber:
+                try:
+                    flow_run_id = uuid.UUID(
+                        event.resource["prefect.resource.id"].replace(
+                            "prefect.flow-run.", "",
+                        )
                     )
-                )
-                self.on_cancelling(flow_run_id)
-            except ValueError:
-                self.logger.debug(
-                    "Received event with invalid flow run ID: %s",
-                    event.resource["prefect.resource.id"],
-                )
+                    self.on_cancelling(flow_run_id)
+                except ValueError:
+                    self.logger.debug(
+                        "Received event with invalid flow run ID: %s",
+                        event.resource["prefect.resource.id"],
+                    )
+        except ConnectionClosedError:
+            self.logger.debug("Events subscriber connection closed")
 
     async def __aenter__(self):
         self._events_subscriber = await self._exit_stack.enter_async_context(
@@ -58,3 +62,4 @@ class FlowRunCancellingObserver:
             pass
         except Exception:
             self.logger.exception("Error consuming events")
+

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -1205,54 +1205,61 @@ class BaseWorker(abc.ABC, Generic[C, V, R]):
         """
         run_logger = self.get_flow_run_logger(flow_run)
 
-        if flow_run.deployment_id:
-            try:
-                await self.client.read_deployment(flow_run.deployment_id)
-            except ObjectNotFound:
-                self._logger.exception(
-                    f"Deployment {flow_run.deployment_id} no longer exists. "
-                    f"Flow run {flow_run.id} will not be submitted for"
-                    " execution"
-                )
-                self._submitting_flow_run_ids.remove(flow_run.id)
-                await self._mark_flow_run_as_cancelled(
-                    flow_run,
-                    state_updates=dict(
-                        message=f"Deployment {flow_run.deployment_id} no longer exists, cancelled run."
-                    ),
-                )
-                return
-
-        ready_to_submit = await self._propose_pending_state(flow_run)
-        self._logger.debug(f"Ready to submit {flow_run.id}: {ready_to_submit}")
-        if ready_to_submit:
-            if TYPE_CHECKING:
-                assert self._runs_task_group is not None
-            readiness_result = await self._runs_task_group.start(
-                self._submit_run_and_capture_errors, flow_run
-            )
-
-            if readiness_result and not isinstance(readiness_result, Exception):
+        try:
+            if flow_run.deployment_id:
                 try:
-                    await self.client.update_flow_run(
-                        flow_run_id=flow_run.id,
-                        infrastructure_pid=str(readiness_result),
+                    await self.client.read_deployment(flow_run.deployment_id)
+                except ObjectNotFound:
+                    self._logger.exception(
+                        f"Deployment {flow_run.deployment_id} no longer exists. "
+                        f"Flow run {flow_run.id} will not be submitted for"
+                        " execution"
                     )
-                except Exception:
-                    run_logger.exception(
-                        "An error occurred while setting the `infrastructure_pid` on "
-                        f"flow run {flow_run.id!r}. The flow run will "
-                        "not be cancellable."
+                    self._submitting_flow_run_ids.remove(flow_run.id)
+                    await self._mark_flow_run_as_cancelled(
+                        flow_run,
+                        state_updates=dict(
+                            message=f"Deployment {flow_run.deployment_id} no longer exists, cancelled run."
+                        ),
                     )
+                    return
 
-                run_logger.info(f"Completed submission of flow run '{flow_run.id}'")
+            ready_to_submit = await self._propose_pending_state(flow_run)
+            self._logger.debug(f"Ready to submit {flow_run.id}: {ready_to_submit}")
+            if ready_to_submit:
+                if TYPE_CHECKING:
+                    assert self._runs_task_group is not None
+                readiness_result = await self._runs_task_group.start(
+                    self._submit_run_and_capture_errors, flow_run
+                )
 
+                if readiness_result and not isinstance(readiness_result, Exception):
+                    try:
+                        await self.client.update_flow_run(
+                            flow_run_id=flow_run.id,
+                            infrastructure_pid=str(readiness_result),
+                        )
+                    except Exception:
+                        run_logger.exception(
+                            "An error occurred while setting the `infrastructure_pid` on "
+                            f"flow run {flow_run.id!r}. The flow run will "
+                            "not be cancellable."
+                        )
+
+                    run_logger.info(f"Completed submission of flow run '{flow_run.id}'")
+
+                else:
+                    # If the run is not ready to submit, release the concurrency slot
+                    self._release_limit_slot(flow_run.id)
             else:
-                # If the run is not ready to submit, release the concurrency slot
                 self._release_limit_slot(flow_run.id)
-        else:
+        except Exception:
+            run_logger.exception(
+                f"An error occurred while submitting flow run '{flow_run.id}'"
+            )
             self._release_limit_slot(flow_run.id)
-        self._submitting_flow_run_ids.remove(flow_run.id)
+        finally:
+            self._submitting_flow_run_ids.discard(flow_run.id)
 
     async def _submit_run_and_capture_errors(
         self,

--- a/tests/runner/test_observers.py
+++ b/tests/runner/test_observers.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from websockets.exceptions import ConnectionClosedError
+
+from prefect.runner._observers import FlowRunCancellingObserver
+
+
+class _RaisingSubscriber:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise ConnectionClosedError(1000, "closed")
+
+
+async def test_observer_handles_connection_closed_error():
+    observer = FlowRunCancellingObserver(lambda _: None)
+    observer._events_subscriber = _RaisingSubscriber()
+
+    # Should complete without raising
+    await observer._consume_events()
+

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -476,6 +476,28 @@ async def test_worker_releases_limit_slot_when_aborting_a_change_to_pending(
     release_mock.assert_called_once_with(flow_run.id)
 
 
+async def test_submit_run_releases_limit_on_exception(
+    prefect_client: PrefectClient,
+    worker_deployment_wq1: WorkQueue,
+    work_pool: WorkPool,
+):
+    flow_run = await prefect_client.create_flow_run_from_deployment(
+        worker_deployment_wq1.id,
+        state=Scheduled(scheduled_time=now_fn("UTC") - timedelta(days=1)),
+    )
+
+    release_mock = Mock()
+
+    async with WorkerTestImpl(work_pool_name=work_pool.name, limit=1) as worker:
+        worker._propose_pending_state = AsyncMock(side_effect=Exception("boom"))
+        worker._release_limit_slot = release_mock
+
+        with pytest.raises(Exception, match="boom"):
+            await worker._submit_run(flow_run)
+
+    release_mock.assert_called_once_with(flow_run.id)
+
+
 async def test_worker_with_work_pool_and_limit(
     prefect_client: PrefectClient,
     worker_deployment_wq1: WorkQueue,


### PR DESCRIPTION
## Summary
- ensure worker releases capacity limiter slot and cleans up when flow-run submission fails
- handle `ConnectionClosedError` in flow run cancelling observer
- add tests covering limiter release and observer shutdown

## Testing
- `pre-commit run --files src/prefect/workers/base.py src/prefect/runner/_observers.py tests/workers/test_base_worker.py tests/runner/test_observers.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not connect to proxy)*
- `pytest tests/runner/test_observers.py tests/workers/test_base_worker.py::test_submit_run_releases_limit_on_exception -q` *(failed: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_6895f05f5fe48323ada03c466688d0c5