### PR TITLE
Fix event text search concatenation for SQLite and other dialects

### DIFF
--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -719,9 +719,16 @@ class EventTextFilter(EventDataFilter):
         resource_field = sa.cast(db.Event.resource, sa.Text)
         related_field = sa.cast(db.Event.related, sa.Text)
 
-        # Combine all searchable fields
-        searchable_field = sa.func.concat(
-            event_field, " ", resource_field, " ", related_field, " ", payload_field
+        # Combine all searchable fields in a way that works across dialects (SQLite
+        # lacks a concat() function) and is resilient to NULLs.
+        searchable_field = (
+            sa.func.coalesce(event_field, "")
+            + sa.literal(" ")
+            + sa.func.coalesce(resource_field, "")
+            + sa.literal(" ")
+            + sa.func.coalesce(related_field, "")
+            + sa.literal(" ")
+            + sa.func.coalesce(payload_field, "")
         )
 
         # Handle include terms (OR logic)


### PR DESCRIPTION
### Motivation
- The event text search SQL previously used `concat()` which is not supported by SQLite and caused cross-dialect failures in text-search queries.
- The searchable field needs to be NULL-safe and work consistently across database dialects so tests and queries behave the same on SQLite and Postgres.

### Description
- Replaced the use of `sa.func.concat(...)` with dialect-independent, NULL-safe concatenation using `sa.func.coalesce(...) + sa.literal(" ") + ...` to build the combined searchable field.
- Kept the same searchable components: `event`, `resource` (JSON), `related` (JSON), and `payload` cast to text, preserving search behavior.
- Change is implemented in `src/prefect/server/events/filters.py` inside `EventTextFilter.build_where_clauses`.

### Testing
- Attempted to run `uv run pytest tests/events/test_events_text_search.py` to validate the change but the test invocation failed before tests executed due to `uv` reporting TOML parse errors in `pyproject.toml` and `uv.lock` in this environment.
- No additional automated tests were added or modified for this change.
- Manual inspection and local reasoning confirm the change avoids usage of `concat()` and is NULL-safe across dialects.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658ad8f9a483239120da88f3a1e1e4)