### PR TITLE
Support sync cancellation on Windows

### DIFF
--- a/src/prefect/_internal/concurrency/cancellation.py
+++ b/src/prefect/_internal/concurrency/cancellation.py
@@ -564,23 +564,22 @@ def cancel_sync_after(timeout: Optional[float], name: Optional[str] = None):
     """
 
     if sys.platform.startswith("win"):
-        yield NullCancelScope(reason="cancellation is not supported on Windows")
-        return
-
-    thread = threading.current_thread()
-    existing_alarm_handler = signal.getsignal(signal.SIGALRM) != signal.SIG_DFL
-
-    if (
-        thread is threading.main_thread()
-        # Avoid nested alarm handlers; it's hard to follow and they will interfere with
-        # each other
-        and not existing_alarm_handler
-        # Avoid using an alarm when there is no timeout; it's better saved for that case
-        and timeout is not None
-    ):
-        scope = AlarmCancelScope(name=name, timeout=timeout)
-    else:
         scope = WatcherThreadCancelScope(name=name, timeout=timeout)
+    else:
+        thread = threading.current_thread()
+        existing_alarm_handler = signal.getsignal(signal.SIGALRM) != signal.SIG_DFL
+
+        if (
+            thread is threading.main_thread()
+            # Avoid nested alarm handlers; it's hard to follow and they will interfere with
+            # each other
+            and not existing_alarm_handler
+            # Avoid using an alarm when there is no timeout; it's better saved for that case
+            and timeout is not None
+        ):
+            scope = AlarmCancelScope(name=name, timeout=timeout)
+        else:
+            scope = WatcherThreadCancelScope(name=name, timeout=timeout)
 
     with scope:
         yield scope


### PR DESCRIPTION
### Motivation
- The sync cancellation helpers were a no-op on Windows, which caused inconsistent cancellation behavior and made the cancellation tests fail in some environments.
- We want cancellation semantics to be enforceable on Windows so tests and runtime behavior match other platforms.

### Description
- Update `cancel_sync_after` to choose `WatcherThreadCancelScope` on Windows instead of returning a `NullCancelScope` no-op.
- Preserve the existing alarm-based `AlarmCancelScope` behavior for non-Windows main-thread cases.
- Minor control-flow restructuring to centralize scope selection logic.

### Testing
- Ran `PYTHONPATH=src python -m pytest tests/_internal/concurrency/test_cancellation.py --confcutdir=tests/_internal -o addopts=` and verified the suite completed with `30 passed`.
- The modified file is `src/prefect/_internal/concurrency/cancellation.py` and the tests exercised both watcher-thread and alarm-based cancellation paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69657e7e0ebc8323a363a29416a222df)