### PR TITLE
Fix text-search concatenation for SQLite (events and logs)

### DIFF
--- a/src/prefect/server/events/filters.py
+++ b/src/prefect/server/events/filters.py
@@ -719,9 +719,16 @@ class EventTextFilter(EventDataFilter):
         resource_field = sa.cast(db.Event.resource, sa.Text)
         related_field = sa.cast(db.Event.related, sa.Text)
 
-        # Combine all searchable fields
-        searchable_field = sa.func.concat(
-            event_field, " ", resource_field, " ", related_field, " ", payload_field
+        # Combine all searchable fields in a way that works across dialects (SQLite
+        # lacks a concat() function) and is resilient to NULLs.
+        searchable_field = (
+            sa.func.coalesce(event_field, "")
+            + sa.literal(" ")
+            + sa.func.coalesce(resource_field, "")
+            + sa.literal(" ")
+            + sa.func.coalesce(related_field, "")
+            + sa.literal(" ")
+            + sa.func.coalesce(payload_field, "")
         )
 
         # Handle include terms (OR logic)

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -1464,8 +1464,13 @@ class LogFilterTextSearch(PrefectFilterBaseModel):
 
         parsed = parse_text_search_query(self.query)
 
-        # Build combined searchable text field (message + name)
-        searchable_field = sa.func.concat(db.Log.message, " ", db.Log.name)
+        # Build combined searchable text field (message + name) in a way that
+        # works across dialects (SQLite lacks concat()) and is NULL-safe.
+        searchable_field = (
+            sa.func.coalesce(db.Log.message, "")
+            + sa.literal(" ")
+            + sa.func.coalesce(db.Log.name, "")
+        )
 
         # Handle include terms (OR logic)
         if parsed.include:


### PR DESCRIPTION
### Motivation
- SQLite does not provide a `concat()` function which caused SQL text-search queries to fail across dialects and triggered test failures in log/event text-search tests.
- The searchable text must be NULL-safe so that missing fields do not break queries or change behavior between SQLite and PostgreSQL.

### Description
- Replaced `sa.func.concat(...)` usage with dialect-independent, NULL-safe concatenation using `sa.func.coalesce(..., "") + sa.literal(" ") + ...` in `src/prefect/server/events/filters.py` to combine `event`, `resource`, `related`, and `payload` fields.
- Applied the same coalesce-based concatenation to the log message/name combination in `src/prefect/server/schemas/filters.py` to avoid `concat()` on SQLite.
- Preserved existing include/exclude/required matching logic that applies `sa.func.lower(...).contains(...)` against the combined searchable field.

### Testing
- No automated test suite was executed in this environment because the test runner tooling failed with TOML parse errors (e.g. `uv` reported parse errors in `pyproject.toml`/`uv.lock`).
- The failures previously observed for `tests/server/api/test_logs_text_search.py` were `sqlite3.OperationalError: no such function: concat`, which this change addresses by removing `concat()` usage.
- Changes were validated by code inspection and local reasoning to ensure NULL-safety and cross-dialect compatibility, but no `pytest` run was completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658ad8f9a483239120da88f3a1e1e4)