### PR TITLE
Adjust runner and block registration tests for new behaviors

### DIFF
--- a/tests/runner/test_observers.py
+++ b/tests/runner/test_observers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
 
 from prefect.runner._observers import FlowRunCancellingObserver
 
@@ -10,7 +11,7 @@ class _RaisingSubscriber:
         return self
 
     async def __anext__(self):
-        raise ConnectionClosedError(1000, "closed")
+        raise ConnectionClosedError(Close(1000, "closed"), None)
 
 
 async def test_observer_handles_connection_closed_error():
@@ -19,4 +20,3 @@ async def test_observer_handles_connection_closed_error():
 
     # Should complete without raising
     await observer._consume_events()
-

--- a/tests/runner/test_storage.py
+++ b/tests/runner/test_storage.py
@@ -30,6 +30,12 @@ def tmp_cwd(monkeypatch, tmp_path):
     monkeypatch.chdir(str(tmp_path))
 
 
+def _run_process_result(stdout: str = "") -> MagicMock:
+    result_mock = MagicMock()
+    result_mock.stdout = stdout.encode()
+    return result_mock
+
+
 class TestCreateStorageFromSource:
     @pytest.mark.parametrize(
         "url, expected_type",
@@ -297,6 +303,15 @@ class TestGitRepository:
     ):
         # pretend the repo already exists
         monkeypatch.setattr("pathlib.Path.exists", lambda x: ".git" in str(x))
+        mock_run_process.side_effect = [
+            _run_process_result("https://github.com/org/repo.git"),
+            _run_process_result("false"),
+            _run_process_result(),
+            _run_process_result(),
+            _run_process_result("head-sha"),
+            _run_process_result("remote-sha"),
+            _run_process_result(),
+        ]
 
         repo = GitRepository(
             url="https://github.com/org/repo.git",
@@ -317,6 +332,18 @@ class TestGitRepository:
             ),
             call(
                 ["git", "sparse-checkout", "set", "dir_1", "dir_2"],
+                cwd=Path.cwd() / "repo",
+            ),
+            call(
+                ["git", "fetch", "--depth", "1", "origin"],
+                cwd=Path.cwd() / "repo",
+            ),
+            call(
+                ["git", "rev-parse", "HEAD"],
+                cwd=Path.cwd() / "repo",
+            ),
+            call(
+                ["git", "rev-parse", "origin/HEAD"],
                 cwd=Path.cwd() / "repo",
             ),
             call(["git", "pull", "origin", "--depth", "1"], cwd=Path.cwd() / "repo"),
@@ -378,7 +405,7 @@ class TestGitRepository:
             url="https://github.com/org/repo.git", include_submodules=True
         )
         await repo.pull_code()
-        mock_run_process.assert_awaited_with(
+        mock_run_process.assert_awaited_once_with(
             [
                 "git",
                 "clone",
@@ -392,19 +419,47 @@ class TestGitRepository:
 
         # pretend the repo already exists
         monkeypatch.setattr("pathlib.Path.exists", lambda x: ".git" in str(x))
+        mock_run_process.reset_mock()
+        mock_run_process.side_effect = [
+            _run_process_result("https://github.com/org/repo.git"),
+            _run_process_result(),
+            _run_process_result("head-sha"),
+            _run_process_result("remote-sha"),
+            _run_process_result(),
+        ]
 
         await repo.pull_code()
-        mock_run_process.assert_awaited_with(
-            [
-                "git",
-                "pull",
-                "origin",
-                "--recurse-submodules",
-                "--depth",
-                "1",
-            ],
-            cwd=Path.cwd() / "repo",
-        )
+        expected_calls = [
+            call(
+                ["git", "config", "--get", "remote.origin.url"],
+                cwd=str(Path.cwd() / "repo"),
+            ),
+            call(
+                ["git", "fetch", "--depth", "1", "origin"],
+                cwd=Path.cwd() / "repo",
+            ),
+            call(
+                ["git", "rev-parse", "HEAD"],
+                cwd=Path.cwd() / "repo",
+            ),
+            call(
+                ["git", "rev-parse", "origin/HEAD"],
+                cwd=Path.cwd() / "repo",
+            ),
+            call(
+                [
+                    "git",
+                    "pull",
+                    "origin",
+                    "--recurse-submodules",
+                    "--depth",
+                    "1",
+                ],
+                cwd=Path.cwd() / "repo",
+            ),
+        ]
+        mock_run_process.assert_has_awaits(expected_calls)
+        assert mock_run_process.await_args_list == expected_calls
 
     async def test_include_submodules_with_credentials(
         self, mock_run_process: AsyncMock, monkeypatch
@@ -1089,7 +1144,15 @@ class TestGitRepository:
             stderr=b"fatal: https://oauth2:secret@github.com/org/repo.git",
         )
 
-        run_process_mock = AsyncMock(side_effect=[success, error])
+        run_process_mock = AsyncMock(
+            side_effect=[
+                success,
+                _run_process_result(),
+                _run_process_result("head-sha"),
+                _run_process_result("remote-sha"),
+                error,
+            ]
+        )
         monkeypatch.setattr("prefect.runner.storage.run_process", run_process_mock)
         clone_mock = AsyncMock()
         monkeypatch.setattr(GitRepository, "_clone_repo", clone_mock)

--- a/tests/server/models/test_block_registration.py
+++ b/tests/server/models/test_block_registration.py
@@ -18,13 +18,16 @@ from prefect.utilities.dispatch import get_registry_for_type
 async def expected_number_of_registered_block_types():
     collections_blocks_data = await _load_collection_blocks_data()
 
-    block_types_from_collections = [
-        block_type
+    collection_block_slugs = {
+        block_type["slug"]
         for collection in collections_blocks_data["collections"].values()
         for block_type in collection["block_types"].values()
-    ]
+    }
     block_registry = get_registry_for_type(Block) or {}
-    return len(block_types_from_collections) + len(block_registry.values())
+    registry_block_slugs = {
+        block_class.get_block_type_slug() for block_class in block_registry.values()
+    }
+    return len(collection_block_slugs | registry_block_slugs)
 
 
 class TestRunAutoRegistration:


### PR DESCRIPTION
### Motivation
- Tests were failing due to small behavioral differences in websocket exceptions, `git` pull logic, and how block registration counts are computed, causing assertions to fail in CI.

### Description
- Update `tests/runner/test_observers.py` to construct `ConnectionClosedError` with a `Close` frame (`from websockets.frames import Close`) to match the newer `websockets` exception shape used by the observer code.
- Extend and make deterministic the `run_process` mock sequences in `tests/runner/test_storage.py` so `GitRepository` tests account for additional calls made when checking repository up-to-dateness and sparse-checkout checks, and add a helper `_run_process_result` to create expected `stdout` mocks.
- Change `tests/server/models/test_block_registration.py` to compute the expected number of registered blocks using unique block slugs by taking the union of collection slugs and registry slugs to avoid double-counting overlaps.

### Testing
- No automated test run was executed as part of this change (`pytest` was not invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966b82f5f8483238ee0d10d3c65ea4b)