### PR TITLE
Use fcntl file locks for git pulls

### DIFF
--- a/src/prefect/runner/storage.py
+++ b/src/prefect/runner/storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fcntl
 import shutil
 import subprocess
 from copy import deepcopy
@@ -15,6 +16,7 @@ from typing import (
 from urllib.parse import urlparse, urlsplit, urlunparse
 from uuid import uuid4
 
+import anyio
 import fsspec  # pyright: ignore[reportMissingTypeStubs]
 from anyio import run_process
 from pydantic import SecretStr
@@ -23,7 +25,6 @@ from prefect._internal.concurrency.api import create_call, from_async
 from prefect.blocks.core import Block, BlockNotSavedError
 from prefect.blocks.system import Secret
 from prefect.filesystems import ReadableDeploymentStorage, WritableDeploymentStorage
-from prefect.locking.filesystem import FileSystemLockManager
 from prefect.logging.loggers import get_logger
 from prefect.utilities.collections import visit_collection
 from prefect.utilities.urls import redact_url_credentials
@@ -355,8 +356,11 @@ class GitRepository:
             )
             return False
 
-    def _git_lock_key(self) -> str:
-        return f"prefect-git-pull-{self.destination.as_posix().strip('/').replace('/', '_')}"
+    def _git_lock_path(self) -> Path:
+        sanitized_destination = (
+            self.destination.as_posix().strip("/").replace("/", "_")
+        )
+        return Path("/tmp") / f"prefect-git-pull-{sanitized_destination}.lock"
 
     async def pull_code(self) -> None:
         """
@@ -367,13 +371,17 @@ class GitRepository:
             self._name,
             self.destination,
         )
-        lock_manager = FileSystemLockManager(self.destination.parent)
-        lock_key = self._git_lock_key()
-        lock_holder = str(uuid4())
-        if not await lock_manager.aacquire_lock(lock_key, lock_holder):
+
+        lock_file = self._git_lock_path().open("a+")
+        try:
+            await anyio.to_thread.run_sync(
+                fcntl.flock, lock_file.fileno(), fcntl.LOCK_EX
+            )
+        except Exception as exc:
+            lock_file.close()
             raise RuntimeError(
                 f"Failed to acquire git lock for repository {self._name!r}."
-            )
+            ) from exc
 
         try:
             git_dir = self.destination / ".git"
@@ -487,7 +495,12 @@ class GitRepository:
             else:
                 await self._clone_repo()
         finally:
-            lock_manager.release_lock(lock_key, lock_holder)
+            try:
+                await anyio.to_thread.run_sync(
+                    fcntl.flock, lock_file.fileno(), fcntl.LOCK_UN
+                )
+            finally:
+                lock_file.close()
 
     async def _clone_repo(self):
         """


### PR DESCRIPTION
### Motivation
- The existing `FileSystemLockManager`-based locking was not providing the documented OS-level file locking semantics. 
- Use a proper OS-level lock file in `/tmp` to avoid relying on storage directories that may not exist and to ensure reliable mutual exclusion across processes.

### Description
- Replace usage of `FileSystemLockManager` with an OS-level `fcntl.flock`-based lock acquired via `anyio.to_thread.run_sync` to avoid blocking the event loop. 
- Add a `_git_lock_path` helper that returns a lock file path in `/tmp` using the sanitized `destination` (`destination.as_posix().strip('/').replace('/', '_')`).
- Open the lock file with `open('a+')`, acquire an exclusive lock with `fcntl.flock(..., fcntl.LOCK_EX)`, and release it with `fcntl.LOCK_UN` in a `finally` block, ensuring the file is always closed. 
- Remove the `FileSystemLockManager` import and add `fcntl` and `anyio` imports to support the new locking approach.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696814a4b8f4832389f1cde93f1c479f)